### PR TITLE
support database IDs too (as well as PIDs) #8720

### DIFF
--- a/doc/sphinx-guides/source/admin/metadataexport.rst
+++ b/doc/sphinx-guides/source/admin/metadataexport.rst
@@ -24,7 +24,7 @@ In addition to the automated exports, a Dataverse installation admin can start a
 
 ``curl http://localhost:8080/api/admin/metadata/clearExportTimestamps``
 
-``curl http://localhost:8080/api/admin/metadata/reExportDataset?persistentId=doi:10.5072/FK2/AAA000``
+``curl http://localhost:8080/api/admin/metadata/:persistentId/reExportDataset?persistentId=doi:10.5072/FK2/AAA000``
 
 The first will attempt to export all the published, local (non-harvested) datasets that haven't been exported yet. 
 The second will *force* a re-export of every published, local dataset, regardless of whether it has already been exported or not. 
@@ -36,6 +36,10 @@ The difference is that when exporting prematurely fails due to some problem, the
 Calling clearExportTimestamps should return ``{"status":"OK","data":{"message":"cleared: X"}}`` where "X" is the total number of datasets cleared.
 
 The reExportDataset call gives you the opportunity to *force* a re-export of only a specific dataset and (with some script automation) could allow you the export specific batches of datasets. This might be usefull when handling exporting problems or when reExportAll takes too much time and is overkill. Note that :ref:`export-dataset-metadata-api` is a related API.
+
+reExportDataset can be called with either ``persistentId`` (as shown above, with a DOI) or with the database id of a dataset (as shown below, with "42" as the database id).
+
+``curl http://localhost:8080/api/admin/metadata/42/reExportDataset``
 
 Note, that creating, modifying, or re-exporting an OAI set will also attempt to export all the unexported datasets found in the set.
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Metadata.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Metadata.java
@@ -68,22 +68,14 @@ public class Metadata extends AbstractApiBean {
     }
 
     @GET
-    @Path("reExportDataset")
-    public Response indexDatasetByPersistentId(@QueryParam("persistentId") String persistentId) {
-        if (persistentId == null) {
-            return error(Response.Status.BAD_REQUEST, "No persistent id given.");
-        }
-        Dataset dataset = null;
+    @Path("{id}/reExportDataset")
+    public Response indexDatasetByPersistentId(@PathParam("id") String id) {
         try {
-            dataset = datasetService.findByGlobalId(persistentId);
-        } catch (Exception ex) {
-            return error(Response.Status.BAD_REQUEST, "Problem looking up dataset with persistent id \"" + persistentId + "\". Error: " + ex.getMessage());
-        }
-        if (dataset != null) {
+            Dataset dataset = findDatasetOrDie(id);
             datasetService.reExportDatasetAsync(dataset);
             return ok("export started");
-        } else {
-            return error(Response.Status.BAD_REQUEST, "Could not find dataset with persistent id " + persistentId);
+        } catch (WrappedResponse wr) {
+            return wr.getResponse();
         }
     }
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -649,6 +649,10 @@ public class DatasetsIT {
         reexportAllFormats.prettyPrint();
         reexportAllFormats.then().assertThat().statusCode(OK.getStatusCode());
 
+        Response reexportAllFormatsUsingId = UtilIT.reexportDatasetAllFormats(datasetId.toString());
+        reexportAllFormatsUsingId.prettyPrint();
+        reexportAllFormatsUsingId.then().assertThat().statusCode(OK.getStatusCode());
+
         Response deleteDatasetResponse = UtilIT.destroyDataset(datasetId, apiToken);
         deleteDatasetResponse.prettyPrint();
         assertEquals(200, deleteDatasetResponse.getStatusCode());

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -1831,9 +1831,15 @@ public class UtilIT {
                 .get("/api/datasets/export" + "?persistentId=" + datasetPersistentId + "&exporter=" + exporter);
     }
 
-    static Response reexportDatasetAllFormats(String datasetPersistentId) {
+    static Response reexportDatasetAllFormats(String idOrPersistentId) {
+        String idInPath = idOrPersistentId; // Assume it's a number.
+        String optionalQueryParam = ""; // If idOrPersistentId is a number we'll just put it in the path.
+        if (!NumberUtils.isDigits(idOrPersistentId)) {
+            idInPath = ":persistentId";
+            optionalQueryParam = "?persistentId=" + idOrPersistentId;
+        }
         return given()
-                .get("/api/admin/metadata/reExportDataset?persistentId=" + datasetPersistentId);
+                .get("/api/admin/metadata/" + idInPath + "/reExportDataset" + optionalQueryParam);
     }
 
     static Response exportDataverse(String identifier, String apiToken) {


### PR DESCRIPTION
Hi @PaulBoon as promised, here's a PR to allow `reExportDataset` to support both PIDs and database IDs.

Please note that the path of the URL changed. I think I updated the docs properly.